### PR TITLE
add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(  name='sv2',
             
         ),
 	include_dirs=[numpy.get_include()],
+        python_requires='~=2.7',
         requires=[
                 'cython',
                 'json',


### PR DESCRIPTION
Added `python_requires='~=2.7'` to `setup.py`.
This specifies that this package only supports Python 2.7.* and is understood by pip (v>=9).
See: https://packaging.python.org/tutorials/distributing-packages/#python-requires.

This should make the Python 2.7 requirement more obvious (for people like me who didn't read the docs).

